### PR TITLE
fix `emmet-ls` ls config

### DIFF
--- a/lua/user/lsp/settings/emmet_ls.lua
+++ b/lua/user/lsp/settings/emmet_ls.lua
@@ -1,7 +1,7 @@
 -- https://github.com/pedro757/emmet
 -- npm i -g ls_emmet
 return {
-  cmd = { "ls_emmet", "--stdio" },
+  cmd = { "emmet-ls", "--stdio" },
   filetypes = {
     "html",
     "css",


### PR DESCRIPTION
I don't know, maybe this is due to the fact that on different operating systems,
 the emmet-ls startup command may differ, but in `Linux 5.16.12-arch1-1 GNU/Linux` 
it is launched via [`emmet-ls`](https://github.com/aca/emmet-ls)

I replaced the launch command 'emmet-ls' in 'nvim/lua/user/lsp/settings/emmet_ls.lua' 
with 'ls_emmet' with 'emmet-ls' and the problem disappeared.

to reproduce the error, you can try to open any file that uses the lsp server 'emmet-ls`

[Screenshot](https://ibb.co/ggkKQgv)
